### PR TITLE
test only files whose extension is js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tape": "^4.2.1"
   },
   "scripts": {
-    "test": "standard && standard .these/aren\\'t/the/source/files/you\\'re/looking/for.js && find test -type f ! -name '_*' -print0 | xargs -0 -n1 -t node"
+    "test": "standard && standard .these/aren\\'t/the/source/files/you\\'re/looking/for.js && find test -type f ! -name '*.js' -print0 | xargs -0 -n1 -t node"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead of ignoring `_*` files, it is better to test only `*.js` files.
This avoids accidental testing of temporary files created by editors.
Rename the `_fake-cl.js` to `_fake-ci` so that it will be excluded from
the tests and the modules can still `require` them without any changes.