### PR TITLE
Include repository name in badge URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ README:
 Markdown snippet:
 
 ```md
-[![volkswagen status](https://auchenberg.github.io/volkswagen/volkswargen_ci.svg?v=1)](https://github.com/auchenberg/volkswagen)
+[![volkswagen status](https://auchenberg.github.io/volkswagen/volkswargen_ci.svg?v=1&repo=user/project)](https://github.com/auchenberg/volkswagen)
 ```
+
+Where `user/project` is the GitHub repository name.
 
 ## Installation
 


### PR DESCRIPTION
I’ve added a `repo` URI parameter to the example code for the Volkswagen badge URI, to ensure that the correct status for a given project is reported. After all, nobody wants to accidentally report the CI status of a different project.

In the future, this could be extended to projects not hosted on GitHub.